### PR TITLE
Implemented TaperTrace and TaperCPW

### DIFF
--- a/src/paths/contstyles/cpw.jl
+++ b/src/paths/contstyles/cpw.jl
@@ -38,8 +38,9 @@ copy(x::SimpleCPW) = SimpleCPW(x.trace, x.gap)
     CPW(trace, gap::Coordinate)
     CPW(trace::Coordinate, gap)
     CPW(trace, gap)
-Constructors for CPW styles. Automatically chooses between `SimpleCPW` or
-`GeneralCPW` styles as appropriate.
+    CPW(trace_start::Coordinate, gap_start::Coordinate, trace_end::Coordinate, gap_end::Coordinate)
+Constructors for CPW styles. Automatically chooses between `SimpleCPW`,
+`GeneralCPW`, or `TaperCPW` styles as appropriate.
 """
 function CPW(trace::Coordinate, gap::Coordinate)
     dimension(trace) != dimension(gap) && throw(DimensionError(trace,gap))

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -1,0 +1,38 @@
+struct TaperTrace{T<:Coordinate} <: Trace
+    width_start::T
+    width_end::T
+end
+copy(x::TaperTrace) = TaperTrace(x.width_start, x_width_end)
+@inline extent(s::TaperTrace, t) = s.width_start/2  + (s.width_end - s.width_start)*t/2
+@inline width(s::TaperTrace, t) = s.width_start + (s.width_end - s.width_start)*t
+function Trace(width_start::Coordinate, width_end::Coordinate)
+    dimension(width_start) != dimension(width_end) && throw(DimensionError(trace,gap))
+    w_s,w_e = promote(float(width_start), float(width_end))
+    TaperTrace(w_s, w_e)
+end
+
+struct TaperCPW{T<:Coordinate} <: CPW
+    trace_start::T
+    gap_start::T
+    trace_end::T
+    gap_end::T
+end
+copy(x::TaperCPW) = TaperCPW(x.trace_start, x.gap_start, x.trace_end, x.gap_end)
+@inline extent(s::TaperCPW, t) = s.trace_start/2 + s.gap_start + (s.trace_end/2-s.trace_start/2 + s.gap_end-s.gap_start)*t
+@inline trace(s::TaperCPW, t) = s.trace_start + (s.trace_end-s.trace_start)*t
+@inline gap(s::TaperCPW, t) = s.gap_start + (s.gap_end-s.gap_start)*t
+function CPW(trace_start::Coordinate, gap_start::Coordinate, trace_end::Coordinate, gap_end::Coordinate)
+    ((dimension(trace_start) != dimension(gap_start)
+        || dimension(trace_end) != dimension(gap_end)
+        || dimension(trace_start) != dimension(trace_end))
+        && throw(DimensionError(trace,gap)))
+    t_s,g_s,t_e,g_e = promote(float(trace_start), float(gap_start), float(trace_end), float(gap_end))
+    TaperCPW(t_s, g_s, t_e, g_e)
+end
+
+summary(s::TaperTrace) = string("Tapered trace with initial width ", s.width_start,
+                                " and final width ", s.width_end)
+summary(s::TaperCPW) = string("Tapered CPW with initial width ", s.trace_start,
+                               " and initial gap ", s.gap_start,
+                               " tapers to a final width ", s.trace_end,
+                               " and final gap ", s.gap_end)

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -36,3 +36,17 @@ summary(s::TaperCPW) = string("Tapered CPW with initial width ", s.trace_start,
                                " and initial gap ", s.gap_start,
                                " tapers to a final width ", s.trace_end,
                                " and final gap ", s.gap_end)
+
+struct Taper <: ContinuousStyle end
+copy(::Taper) = Taper()
+
+"""
+    Taper()
+Constructor for generic Taper style. Will automatically create tapered region
+between CPW/Trace and another CPW/Trace of different dimensions
+"""
+Taper
+
+summary(::Taper) = string("Generic tapered region constructign a linear taper ",
+                          "between the segment before and segment after its ",
+                          "place in the path")

--- a/src/paths/contstyles/trace.jl
+++ b/src/paths/contstyles/trace.jl
@@ -30,8 +30,9 @@ copy(x::SimpleTrace) = Trace(x.width)
 """
     Trace(width)
     Trace(width::Coordinate)
-Constructor for Trace styles. Automatically chooses `SimpleTrace` or `GeneralTrace` as
-appropriate.
+    Trace(width_start::Coordinate, width_end::Coordinate)
+Constructor for Trace styles. Automatically chooses `SimpleTrace`, `GeneralTrace`,
+and `TaperTrace` as appropriate.
 """
 Trace(width) = GeneralTrace(width)
 Trace(width::Coordinate) = SimpleTrace(float(width))

--- a/src/paths/paths.jl
+++ b/src/paths/paths.jl
@@ -430,6 +430,7 @@ include("contstyles/trace.jl")
 include("contstyles/cpw.jl")
 include("contstyles/compound.jl")
 include("contstyles/decorated.jl")
+include("contstyles/tapers.jl")
 include("discretestyles/simple.jl")
 include("norender.jl")
 

--- a/src/render/render.jl
+++ b/src/render/render.jl
@@ -6,6 +6,7 @@ include("trace.jl")
 include("cpw.jl")
 include("decorated.jl")
 include("compound.jl")
+include("tapers.jl")
 
 # Generic fallback method
 # If there's no specific method for this segment type, use the fallback method for the style.

--- a/src/render/tapers.jl
+++ b/src/render/tapers.jl
@@ -1,0 +1,92 @@
+# Rendering of arbitrary segments
+function render!(c::Cell, f, len, s::Paths.TaperTrace, meta::Meta; kwargs...)
+    bnds = (zero(len), len)
+
+    # Minor change here - geometry is paramatrized in a dimensionless way
+    g = (t,sgn)->begin
+        d = Paths.direction(f,t) + sgn * π/2
+        return f(t) + Paths.extent(s,t/len) * Point(cos(d),sin(d))
+    end
+
+    pgrid = adapted_grid(t->Paths.direction(r->g(r, 1), t), bnds; kwargs...)
+    mgrid = adapted_grid(t->Paths.direction(r->g(r,-1), t), bnds; kwargs...)
+
+    pts = [g.(pgrid, 1); @view (g.(mgrid, -1))[end:-1:1]]
+
+    render!(c, Polygon(pts), Polygons.Plain(), meta)
+end
+
+function render!(c::Cell, f, len, s::Paths.TaperCPW, meta::Meta; kwargs...)
+    bnds = (zero(len), len)
+
+    # Minor change here - geometry is paramatrized in a dimensionless way
+    g = (t,sgn1,sgn2)->begin
+        d = Paths.direction(f,t) + sgn1 * π/2       # turn left (+) or right (-) of path
+        offset = (Paths.gap(s,t/len) + Paths.trace(s,t/len)) / 2
+        return f(t) + (sgn2 * Paths.gap(s,t/len)/2 + offset) * Point(cos(d),sin(d))
+    end
+
+    ppgrid = adapted_grid(t->Paths.direction(r->g(r,  1,  1), t), bnds; kwargs...)
+    pmgrid = adapted_grid(t->Paths.direction(r->g(r,  1, -1), t), bnds; kwargs...)
+    mmgrid = adapted_grid(t->Paths.direction(r->g(r, -1, -1), t), bnds; kwargs...)
+    mpgrid = adapted_grid(t->Paths.direction(r->g(r, -1,  1), t), bnds; kwargs...)
+
+    ppts = [g.(ppgrid,  1,  1); @view (g.(pmgrid,  1, -1))[end:-1:1]]
+    mpts = [g.(mmgrid, -1, -1); @view (g.(mpgrid, -1,  1))[end:-1:1]]
+
+    render!(c, Polygon(ppts), Polygons.Plain(), meta)
+    render!(c, Polygon(mpts), Polygons.Plain(), meta)
+end
+
+# Optimized rendering of straight tapered segments
+function render!(c::Cell, segment::Paths.Straight{T}, s::Paths.TaperTrace, meta::Meta; kwargs...) where {T}
+    dir = direction(segment, zero(T))
+    dp, dm = dir+π/2, dir-π/2
+
+    # parametrization of style relies on dimensionless t
+    one_T = one(T)
+    ext_start = Paths.extent(s, zero(one_T))
+    ext_end = Paths.extent(s, one_T)
+
+    tangents = StaticArrays.@SVector [
+        ext_start * Point(cos(dp),sin(dp)),
+        ext_end * Point(cos(dp),sin(dp)),
+        ext_end * Point(cos(dm),sin(dm)),
+        ext_start * Point(cos(dm),sin(dm))
+    ]
+
+    a,b = segment(zero(T)), segment(pathlength(segment))
+    origins = StaticArrays.@SVector [a,b,b,a]
+
+    render!(c, Polygon(origins .+ tangents), Polygons.Plain(), meta)
+end
+
+function render!(c::Cell, segment::Paths.Straight{T}, s::Paths.TaperCPW, meta::Meta; kwargs...) where {T}
+    dir = direction(segment, zero(T))
+    dp = dir+π/2
+
+    # parametrization of style relies on dimensionless t
+    one_T = one(T)
+    ext_start = Paths.extent(s, zero(one_T))
+    ext_end = Paths.extent(s, one_T)
+    trace_start = Paths.trace(s, zero(one_T))
+    trace_end = Paths.trace(s, one_T)
+
+    tangents = StaticArrays.@SVector [
+        Point(cos(dp),sin(dp)),
+        Point(cos(dp),sin(dp)),
+        Point(cos(dp),sin(dp)),
+        Point(cos(dp),sin(dp))
+    ]
+
+    extents_p = StaticArrays.@SVector [ext_start, ext_end,
+                                       trace_end/2., trace_start/2.]
+    extents_m = StaticArrays.@SVector [trace_start/2., trace_end/2.,
+                                       ext_end, ext_start]
+
+    a,b = segment(zero(T)), segment(pathlength(segment))
+    origins = StaticArrays.@SVector [a,b,b,a]
+
+    render!(c, Polygon(origins .+ extents_p .* tangents), Polygons.Plain(), meta)
+    render!(c, Polygon(origins .- extents_m .* tangents), Polygons.Plain(), meta)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1058,6 +1058,92 @@ end
         @test lowerleft(bounds(c.elements[3])) ≈ Point(40μm, -10μm)
         @test upperright(bounds(c.elements[3])) ≈ Point(120μm, 10μm)
     end
+
+    @testset "Auto Taper" begin
+        # Generate a path with different permutations of styles and
+        # test rendering of auto taper style Taper()
+        p1 = Path(μm)
+        straight!(p1, 10μm, Paths.Trace(2.0μm))
+        # element 2, test taper between traces
+        straight!(p1, 10μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.Trace(4.0μm))
+        # element 4, test taper between simple trace and hard-code taper trace
+        straight!(p1, 10μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.Trace(2.0μm, 1.0μm))
+        # element 6, test taper between hard-code trace and general trace
+        straight!(p1, 10μm, Paths.Taper())
+        turn!(p1, -π/2, 10μm, Paths.Trace(2.0μm, 1.0μm))
+        turn!(p1, -π/2, 10μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.Trace(2.0μm))
+        # elements 10, 11, test taper between trace and cpw
+        straight!(p1, 10μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.CPW(2.0μm, 1.0μm))
+        # elements 14, 15, test taper between CPW and CPW
+        straight!(p1, 10μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.CPW(4.0μm, 2.0μm))
+        # elements 18, 19, test taper between CPW and trace
+        straight!(p1, 15μm, Paths.Taper())
+        straight!(p1, 10μm, Paths.Trace(2.0μm))
+
+        c = Cell("pathonly", nm)
+        render!(c, p1, GDSMeta(0))
+
+        p(x,y) = Point(x, y)
+        @test points(c.elements[2]) == Point{typeof(1.0nm)}[
+                p(10000.0nm, 1000.0nm),
+                p(20000.0nm, 2000.0nm),
+                p(20000.0nm, -2000.0nm),
+                p(10000.0nm, -1000.0nm)
+            ]
+        @test points(c.elements[4]) == Point{typeof(1.0nm)}[
+                p(30000.0nm, 2000.0nm),
+                p(40000.0nm, 1000.0nm),
+                p(40000.0nm, -1000.0nm),
+                p(30000.0nm, -2000.0nm)
+            ]
+        @test points(c.elements[6]) == Point{typeof(1.0nm)}[
+                p(50000.0nm, 500.0nm),
+                p(60000.0nm, 1000.0nm),
+                p(60000.0nm, -1000.0nm),
+                p(50000.0nm, -500.0nm)
+            ]
+        @test points(c.elements[10]) == Point{typeof(1.0nm)}[
+                p(50000.0nm, -21000.0nm),
+                p(40000.0nm, -22000.0nm),
+                p(40000.0nm, -21000.0nm),
+                p(50000.0nm, -20000.0nm)
+            ]
+        @test points(c.elements[11]) == Point{typeof(1.0nm)}[
+                p(50000.0nm, -20000.0nm),
+                p(40000.0nm, -19000.0nm),
+                p(40000.0nm, -18000.0nm),
+                p(50000.0nm, -19000.0nm)
+            ]
+        @test points(c.elements[14]) ≈ Point{typeof(1.0nm)}[
+                p(30000.0nm, -22000.0nm),
+                p(20000.0nm, -24000.0nm),
+                p(20000.0nm, -22000.0nm),
+                p(30000.0nm, -21000.0nm)
+            ]
+        @test points(c.elements[15]) ≈ Point{typeof(1.0nm)}[
+                p(30000.0nm, -19000.0nm),
+                p(20000.0nm, -18000.0nm),
+                p(20000.0nm, -16000.0nm),
+                p(30000.0nm, -18000.0nm)
+            ]
+        @test points(c.elements[18]) ≈ Point{typeof(1.0nm)}[
+                p(10000.0nm, -24000.0nm),
+                p(-5000.0nm, -21000.0nm),
+                p(-5000.0nm, -20000.0nm),
+                p(10000.0nm, -22000.0nm)
+            ]
+        @test points(c.elements[19]) ≈ Point{typeof(1.0nm)}[
+                p(10000.0nm, -18000.0nm),
+                p(-5000.0nm, -20000.0nm),
+                p(-5000.0nm, -19000.0nm),
+                p(10000.0nm, -16000.0nm)
+            ]
+    end
 end
 
 @testset "Compound shapes" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -979,6 +979,38 @@ end
 
     end
 
+    @testset "Straight, TaperTrace" begin
+        c = Cell("main", nm)
+        pa = Path(μm)
+        straight!(pa, 50.0μm, Paths.Trace(10.0μm, 6.0μm))
+        render!(c, pa)
+        @test points(c.elements[1]) ≈ Point{typeof(1.0nm)}[
+            p(0.0nm,    5000.0nm),
+            p(50000.0nm, 3000.0nm),
+            p(50000.0nm, -3000.0nm),
+            p(0.0nm, -5000.0nm)
+        ]
+    end
+
+    @testset "Straight, TaperCPW" begin
+        c = Cell("main", nm)
+        pa = Path(μm)
+        straight!(pa, 50.0μm, Paths.CPW(10.0μm, 6.0μm, 8.0μm, 2.0μm))
+        render!(c, pa)
+        @test points(c.elements[1]) ≈ Point{typeof(1.0nm)}[
+            p(0.0nm,    11000.0nm),
+            p(50000.0nm, 6000.0nm),
+            p(50000.0nm, 4000.0nm),
+            p(0.0nm, 5000.0nm)
+        ]
+        @test points(c.elements[2]) ≈ Point{typeof(1.0nm)}[
+            p(0.0nm,    -5000.0nm),
+            p(50000.0nm, -4000.0nm),
+            p(50000.0nm, -6000.0nm),
+            p(0.0nm, -11000.0nm)
+        ]
+    end
+
     @testset "CompoundSegment" begin
         # CompoundSegment, CompoundStyle should render as if the path wasn't simplified,
         # provided that's possible. This is done for rendering and filesize efficiency.


### PR DESCRIPTION
Added TaperTrace and TaperCPW, constructed by calling Trace(width_start, width_end) and CPW(trace_start, gap_start, trace_end, gap_end).

This is a performance/convenience overload to reduce the number of rendered points for tapered structures, where render! has been specialized for straight and arbitrary segments.

Feel free to make suggestions.