### PR TITLE
Fix Taper issues w/ Compound Segments

### DIFF
--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -47,6 +47,6 @@ between CPW/Trace and another CPW/Trace of different dimensions
 """
 Taper
 
-summary(::Taper) = string("Generic tapered region constructign a linear taper ",
+summary(::Taper) = string("Generic tapered region constructing a linear taper ",
                           "between the segment before and segment after its ",
                           "place in the path")

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -5,7 +5,7 @@ end
 copy(x::TaperTrace) = TaperTrace(x.width_start, x_width_end)
 @inline extent(s::TaperTrace, t) = s.width_start/2  + (s.width_end - s.width_start)*t/2
 @inline width(s::TaperTrace, t) = s.width_start + (s.width_end - s.width_start)*t
-function Trace(width_start::Coordinate, width_end::Coordinate)
+function TaperTrace(width_start::Coordinate, width_end::Coordinate)
     dimension(width_start) != dimension(width_end) && throw(DimensionError(trace,gap))
     w_s,w_e = promote(float(width_start), float(width_end))
     TaperTrace(w_s, w_e)
@@ -21,7 +21,7 @@ copy(x::TaperCPW) = TaperCPW(x.trace_start, x.gap_start, x.trace_end, x.gap_end)
 @inline extent(s::TaperCPW, t) = s.trace_start/2 + s.gap_start + (s.trace_end/2-s.trace_start/2 + s.gap_end-s.gap_start)*t
 @inline trace(s::TaperCPW, t) = s.trace_start + (s.trace_end-s.trace_start)*t
 @inline gap(s::TaperCPW, t) = s.gap_start + (s.gap_end-s.gap_start)*t
-function CPW(trace_start::Coordinate, gap_start::Coordinate, trace_end::Coordinate, gap_end::Coordinate)
+function TaperCPW(trace_start::Coordinate, gap_start::Coordinate, trace_end::Coordinate, gap_end::Coordinate)
     ((dimension(trace_start) != dimension(gap_start)
         || dimension(trace_end) != dimension(gap_end)
         || dimension(trace_start) != dimension(trace_end))

--- a/src/render/paths.jl
+++ b/src/render/paths.jl
@@ -73,28 +73,35 @@ function get_taper_style(prevnode, nextnode)
     prevstyle = style(prevnode)
     nextstyle = style(nextnode)
     endof_prev = pathlength(segment(prevnode))
+    # handle case of compound style (#39)
+    if prevstyle isa Paths.CompoundStyle
+        prevstyle = last(prevstyle.styles)
+    end
+    if nextstyle isa Paths.CompoundStyle
+        nextstyle = first(nextstyle.styles)
+    end
     # handle special case of tapers, set endof_prev to normalized dimensionless parameter
-    if typeof(prevstyle) <: Paths.TaperTrace || typeof(prevstyle) <: Paths.TaperCPW
+    if prevstyle isa Paths.TaperTrace || prevstyle isa Paths.TaperCPW
         endof_prev = endof_prev/endof_prev
     end
     beginof_next = zero(pathlength(segment(nextnode)))
     # handle special case of tapers, set beginof_next to normalized dimensionless parameter
-    if typeof(nextstyle) <: Paths.TaperTrace || typeof(nextstyle) <: Paths.TaperCPW
+    if nextstyle isa Paths.TaperTrace || nextstyle isa Paths.TaperCPW
         beginof_next = beginof_next/pathlength(segment(nextnode))
     end
-    if ((typeof(prevstyle) <: Paths.CPW || typeof(prevstyle) <: Paths.Trace)
-        && typeof(nextstyle) <: Paths.CPW || typeof(nextstyle) <: Paths.Trace)
+    if ((prevstyle isa Paths.CPW || prevstyle isa Paths.Trace)
+        && nextstyle isa Paths.CPW || nextstyle isa Paths.Trace)
         #special case: both ends are Traces, make a Paths.TaperTrace
-        if typeof(prevstyle) <: Paths.Trace && typeof(nextstyle) <: Paths.Trace
+        if prevstyle isa Paths.Trace && nextstyle isa Paths.Trace
             thisstyle = Paths.TaperTrace(Paths.width(prevstyle, endof_prev),
                                    Paths.width(nextstyle, beginof_next))
-        elseif typeof(prevstyle) <: Paths.Trace #previous segment is Paths.trace
+        elseif prevstyle isa Paths.Trace #previous segment is Paths.trace
             gap_start = Paths.width(prevstyle, endof_prev)/2.
             trace_end = Paths.trace(nextstyle, beginof_next)
             gap_end = Paths.gap(nextstyle, beginof_next)
             thisstyle = Paths.TaperCPW(zero(gap_start), gap_start,
                                  trace_end, gap_end)
-        elseif typeof(nextstyle) <: Paths.Trace #next segment is Paths.trace
+        elseif nextstyle isa Paths.Trace #next segment is Paths.trace
             trace_start = Paths.trace(prevstyle, endof_prev)
             gap_end = Paths.width(nextstyle, beginof_next)/2.
             gap_start = Paths.gap(prevstyle, endof_prev)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -982,7 +982,7 @@ end
     @testset "Straight, TaperTrace" begin
         c = Cell("main", nm)
         pa = Path(μm)
-        straight!(pa, 50.0μm, Paths.Trace(10.0μm, 6.0μm))
+        straight!(pa, 50.0μm, Paths.TaperTrace(10.0μm, 6.0μm))
         render!(c, pa)
         @test points(c.elements[1]) ≈ Point{typeof(1.0nm)}[
             p(0.0nm,    5000.0nm),
@@ -995,7 +995,7 @@ end
     @testset "Straight, TaperCPW" begin
         c = Cell("main", nm)
         pa = Path(μm)
-        straight!(pa, 50.0μm, Paths.CPW(10.0μm, 6.0μm, 8.0μm, 2.0μm))
+        straight!(pa, 50.0μm, Paths.TaperCPW(10.0μm, 6.0μm, 8.0μm, 2.0μm))
         render!(c, pa)
         @test points(c.elements[1]) ≈ Point{typeof(1.0nm)}[
             p(0.0nm,    11000.0nm),
@@ -1069,10 +1069,10 @@ end
         straight!(p1, 10μm, Paths.Trace(4.0μm))
         # element 4, test taper between simple trace and hard-code taper trace
         straight!(p1, 10μm, Paths.Taper())
-        straight!(p1, 10μm, Paths.Trace(2.0μm, 1.0μm))
+        straight!(p1, 10μm, Paths.TaperTrace(2.0μm, 1.0μm))
         # element 6, test taper between hard-code trace and general trace
         straight!(p1, 10μm, Paths.Taper())
-        turn!(p1, -π/2, 10μm, Paths.Trace(2.0μm, 1.0μm))
+        turn!(p1, -π/2, 10μm, Paths.TaperTrace(2.0μm, 1.0μm))
         turn!(p1, -π/2, 10μm, Paths.Taper())
         straight!(p1, 10μm, Paths.Trace(2.0μm))
         # elements 10, 11, test taper between trace and cpw

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1143,6 +1143,25 @@ end
                 p(-5000.0nm, -19000.0nm),
                 p(10000.0nm, -16000.0nm)
             ]
+
+        # Test Auto-taper compatibility with compound segments
+        p1 = Path(nm)
+        straight!(p1, 100nm, Paths.Trace(10nm))
+        straight!(p1, 100nm, Paths.Trace(10nm))
+        simplify!(p1, 1:2)
+        straight!(p1, 100nm, Paths.Taper())
+        straight!(p1, 100nm, Paths.Trace(20nm))
+        straight!(p1, 100nm, Paths.Trace(20nm))
+        simplify!(p1, 3:4)
+
+        c = Cell("pathonly", nm)
+        render!(c, p1, GDSMeta(0))
+        @test points(c.elements[3]) ≈ Point{typeof(1.0nm)}[
+                p(200.0nm,  5.0nm),
+                p(300.0nm,  10.0nm),
+                p(300.0nm, -10.0nm),
+                p(200.0nm, -5.0nm)
+            ]
     end
 end
 


### PR DESCRIPTION
Ref. #39 

 * Removed the overloads of `Trace` and `CPW`
 * Fixed auto-taper `Taper` style issue with `CompoundSegment` segments

Now paths that undergo `simplify!` (and other `CompoundSegment`s) are compatible with automatic taper detection.

This covers the use cases I have seen but if there are other issues, please let me know.

