### PR TITLE
Rename `adjust!` to `reconcile!`

### DIFF
--- a/src/Devices.jl
+++ b/src/Devices.jl
@@ -150,7 +150,7 @@ include("paths/paths.jl")
 import .Paths: Path,
     α0,
     α1,
-    adjust!,
+    reconcile!,
     attach!,
     contstyle1,
     corner!,
@@ -176,10 +176,12 @@ import .Paths: Path,
     setstyle!,
     turn!,
     undecorated
+
+@deprecate adjust! reconcile!
 export Paths, Path, Segment, Style,
     α0,
     α1,
-    adjust!,
+    adjust!, reconcile!,
     attach!,
     corner!,
     direction,

--- a/src/render/paths.jl
+++ b/src/render/paths.jl
@@ -18,7 +18,7 @@ function render!(c::Cell, p::Path{T}, meta::Meta=GDSMeta(); kwargs...) where {T}
         cornertweaks!(cornernode, prevseg, previous)
         cornertweaks!(cornernode, nextseg, next)
     end
-    !isempty(inds) && adjust!(p)
+    !isempty(inds) && reconcile!(p)
 
     taper_inds = handle_generic_tapers!(p)
 
@@ -31,7 +31,7 @@ function render!(c::Cell, p::Path{T}, meta::Meta=GDSMeta(); kwargs...) where {T}
         setsegment!(next(p[i]), pop!(segs))
         setsegment!(previous(p[i]), pop!(segs))
     end
-    !isempty(inds) && adjust!(p)
+    !isempty(inds) && reconcile!(p)
 
     restore_generic_tapers!(p, taper_inds)
 


### PR DESCRIPTION
The name better indicates what the operation does.

Adds a deprecation for `adjust!` and documentation to `reconcile!` subfunctions.
Clarifies documentation for `reconcile!`.