### PR TITLE
Require that `extent` always takes a path length argument

### DIFF
--- a/src/paths/contstyles/compound.jl
+++ b/src/paths/contstyles/compound.jl
@@ -9,7 +9,7 @@ Combines styles together, typically for use with a [`CompoundSegment`](@ref).
 by the outer constructor.
 - `grid`: An array of `t` values needed for rendering the parameteric path.
 """
-struct CompoundStyle{T<:FloatCoordinate} <: ContinuousStyle
+struct CompoundStyle{T<:FloatCoordinate} <: ContinuousStyle{false}
     styles::Vector{Style}
     grid::Vector{T}
 end

--- a/src/paths/contstyles/cpw.jl
+++ b/src/paths/contstyles/cpw.jl
@@ -1,14 +1,14 @@
-abstract type CPW <: ContinuousStyle end
+abstract type CPW{T} <: ContinuousStyle{T} end
 
 """
-    struct GeneralCPW{S,T} <: CPW
+    struct GeneralCPW{S,T} <: CPW{false}
         trace::S
         gap::T
     end
 A CPW with variable trace and gap as a function of path length. `trace` and `gap` are
 callable.
 """
-struct GeneralCPW{S,T} <: CPW
+struct GeneralCPW{S,T} <: CPW{false}
     trace::S
     gap::T
 end
@@ -24,7 +24,7 @@ copy(x::GeneralCPW) = GeneralCPW(x.trace, x.gap)
     end
 A CPW with fixed trace and gap as a function of path length.
 """
-struct SimpleCPW{T<:Coordinate} <: CPW
+struct SimpleCPW{T<:Coordinate} <: CPW{false}
     trace::T
     gap::T
 end

--- a/src/paths/contstyles/decorated.jl
+++ b/src/paths/contstyles/decorated.jl
@@ -1,5 +1,5 @@
 """
-    mutable struct DecoratedStyle{T<:FloatCoordinate} <: ContinuousStyle
+    mutable struct DecoratedStyle{T<:FloatCoordinate} <: ContinuousStyle{false}
         s::Style
         ts::Array{Float64,1}
         dirs::Array{Int,1}
@@ -7,7 +7,7 @@
     end
 Style with decorations, like structures periodically repeated along the path, etc.
 """
-mutable struct DecoratedStyle{T<:FloatCoordinate} <: ContinuousStyle
+mutable struct DecoratedStyle{T<:FloatCoordinate} <: ContinuousStyle{false}
     s::Style
     ts::Array{T,1}
     dirs::Array{Int,1}

--- a/src/paths/contstyles/strands.jl
+++ b/src/paths/contstyles/strands.jl
@@ -1,7 +1,7 @@
-abstract type Strands <: ContinuousStyle end
+abstract type Strands{T} <: ContinuousStyle{T} end
 
 """
-    struct GeneralStrands{S,T,U} <: Strands
+    struct GeneralStrands{S,T,U} <: Strands{false}
         offset::S
         width::T
         spacing::U
@@ -19,7 +19,7 @@ abstract type Strands <: ContinuousStyle end
 Strands with variable center offset, width, and spacing as a function of path length.
 `offset`, `width`, and `spacing` are callable.
 """
-struct GeneralStrands{S,T,U} <: Strands
+struct GeneralStrands{S,T,U} <: Strands{false}
     offset::S
     width::T
     spacing::U
@@ -33,7 +33,7 @@ copy(x::GeneralStrands) = GeneralStrands(x.offset, x.width, x.spacing, x.num)
 @inline num(s::GeneralStrands, t) = s.num
 
 """
-    struct SimpleStrands{T<:Coordinate} <: Strands
+    struct SimpleStrands{T<:Coordinate} <: Strands{false}
         offset::T
         width::T
         spacing::T
@@ -50,7 +50,7 @@ copy(x::GeneralStrands) = GeneralStrands(x.offset, x.width, x.spacing, x.num)
 
 Strands with fixed center offset, width, and spacing as a function of path length.
 """
-struct SimpleStrands{T<:Coordinate} <: Strands
+struct SimpleStrands{T<:Coordinate} <: Strands{false}
     offset::T
     width::T
     spacing::T

--- a/src/paths/contstyles/tapers.jl
+++ b/src/paths/contstyles/tapers.jl
@@ -1,49 +1,59 @@
 """
-    struct TaperTrace{T<:Coordinate} <: Trace
+    struct TaperTrace{T<:Coordinate} <: Trace{true}
         width_start::T
         width_end::T
+        length::T
     end
 A single trace with a linearly tapered width as a function of path length.
 """
-struct TaperTrace{T<:Coordinate} <: Trace
+struct TaperTrace{T<:Coordinate} <: Trace{true}
     width_start::T
     width_end::T
+    length::T
+    TaperTrace{T}(ws::T, we::T) where {T<:Coordinate} = new{T}(ws, we)
+    TaperTrace{T}(ws::T, we::T, l) where {T<:Coordinate} = new{T}(ws, we, l)
 end
 copy(x::TaperTrace) = TaperTrace(x.width_start, x_width_end)
-@inline extent(s::TaperTrace, t) = s.width_start/2  + (s.width_end - s.width_start)*t/2
-@inline width(s::TaperTrace, t) = s.width_start + (s.width_end - s.width_start)*t
+@inline extent(s::TaperTrace, t) = 0.5 * width(s,t)
+@inline width(s::TaperTrace, t) = (1-t/s.length) * s.width_start + t/s.length * s.width_end
 function TaperTrace(width_start::Coordinate, width_end::Coordinate)
     dimension(width_start) != dimension(width_end) && throw(DimensionError(trace,gap))
     w_s,w_e = promote(float(width_start), float(width_end))
-    TaperTrace(w_s, w_e)
+    return TaperTrace{typeof(w_s)}(w_s, w_e)
 end
 
 """
-    struct TaperCPW{T<:Coordinate} <: CPW
+    struct TaperCPW{T<:Coordinate} <: CPW{true}
         trace_start::T
         gap_start::T
         trace_end::T
         gap_end::T
+        length::T
     end
 A CPW with a linearly tapered trace and gap as a function of path length.
 """
-struct TaperCPW{T<:Coordinate} <: CPW
+struct TaperCPW{T<:Coordinate} <: CPW{true}
     trace_start::T
     gap_start::T
     trace_end::T
     gap_end::T
+    length::T
+    TaperCPW{T}(ts::T, gs::T, te::T, ge::T) where {T<:Coordinate} = new{T}(ts, gs, te, ge)
+    TaperCPW{T}(ts::T, gs::T, te::T, ge::T, l) where {T<:Coordinate} =
+        new{T}(ts, gs, te, ge, l)
 end
 copy(x::TaperCPW) = TaperCPW(x.trace_start, x.gap_start, x.trace_end, x.gap_end)
-@inline extent(s::TaperCPW, t) = s.trace_start/2 + s.gap_start + (s.trace_end/2-s.trace_start/2 + s.gap_end-s.gap_start)*t
-@inline trace(s::TaperCPW, t) = s.trace_start + (s.trace_end-s.trace_start)*t
-@inline gap(s::TaperCPW, t) = s.gap_start + (s.gap_end-s.gap_start)*t
+@inline extent(s::TaperCPW, t) = (1-t/s.length) * (0.5*s.trace_start + s.gap_start) +
+    (t/s.length) * (0.5*s.trace_end + s.gap_end)
+@inline trace(s::TaperCPW, t) = (1-t/s.length) * s.trace_start + t/s.length * s.trace_end
+@inline gap(s::TaperCPW, t) = (1-t/s.length) * s.gap_start + t/s.length * s.gap_end
 function TaperCPW(trace_start::Coordinate, gap_start::Coordinate, trace_end::Coordinate, gap_end::Coordinate)
     ((dimension(trace_start) != dimension(gap_start)
         || dimension(trace_end) != dimension(gap_end)
         || dimension(trace_start) != dimension(trace_end))
         && throw(DimensionError(trace,gap)))
     t_s,g_s,t_e,g_e = promote(float(trace_start), float(gap_start), float(trace_end), float(gap_end))
-    TaperCPW(t_s, g_s, t_e, g_e)
+    return TaperCPW{typeof(t_s)}(t_s, g_s, t_e, g_e)
 end
 
 summary(s::TaperTrace) = string("Tapered trace with initial width ", s.width_start,
@@ -53,17 +63,12 @@ summary(s::TaperCPW) = string("Tapered CPW with initial width ", s.trace_start,
                                " tapers to a final width ", s.trace_end,
                                " and final gap ", s.gap_end)
 
-struct Taper <: ContinuousStyle end
-copy(::Taper) = Taper()
-
 """
     Taper()
-Constructor for generic Taper style. Will automatically create a linearly
-tapered region between an initial `CPW` or `Trace` and an end `CPW` or `Trace`
-of different dimensions. 
+Constructor for generic Taper style. Will automatically create a linearly tapered region
+between an initial `CPW` or `Trace` and an end `CPW` or `Trace` of different dimensions.
 """
-Taper
+struct Taper <: ContinuousStyle{false} end
+copy(::Taper) = Taper()
 
-summary(::Taper) = string("Generic tapered region constructing a linear taper ",
-                          "between the segment before and segment after its ",
-                          "place in the path")
+summary(::Taper) = string("Generic linear taper between neighboring segments in a path")

--- a/src/paths/contstyles/trace.jl
+++ b/src/paths/contstyles/trace.jl
@@ -1,12 +1,12 @@
-abstract type Trace <: ContinuousStyle end
+abstract type Trace{T} <: ContinuousStyle{T} end
 
 """
-    struct GeneralTrace{T} <: Trace
+    struct GeneralTrace{T} <: Trace{false}
         width::T
     end
 A single trace with variable width as a function of path length. `width` is callable.
 """
-struct GeneralTrace{T} <: Trace
+struct GeneralTrace{T} <: Trace{false}
     width::T
 end
 copy(x::GeneralTrace) = GeneralTrace(x.width)
@@ -14,12 +14,12 @@ copy(x::GeneralTrace) = GeneralTrace(x.width)
 @inline width(s::GeneralTrace, t) = s.width(t)
 
 """
-    struct SimpleTrace{T<:Coordinate} <: Trace
+    struct SimpleTrace{T<:Coordinate} <: Trace{false}
         width::T
     end
 A single trace with fixed width as a function of path length.
 """
-struct SimpleTrace{T<:Coordinate} <: Trace
+struct SimpleTrace{T<:Coordinate} <: Trace{false}
     width::T
 end
 SimpleTrace(width) = SimpleTrace(width)

--- a/src/paths/norender.jl
+++ b/src/paths/norender.jl
@@ -1,15 +1,15 @@
 struct NoRender <: Style end
 struct NoRenderDiscrete <: DiscreteStyle end
-struct NoRenderContinuous <: ContinuousStyle end
+struct NoRenderContinuous <: ContinuousStyle{false} end
 
 """
-    struct SimpleNoRender{T} <: ContinuousStyle
+    struct SimpleNoRender{T} <: ContinuousStyle{false}
         width::T
     end
 A style that inhibits path rendering, but pretends to have a finite width for
 [`Paths.attach!`](@ref).
 """
-struct SimpleNoRender{T} <: ContinuousStyle
+struct SimpleNoRender{T} <: ContinuousStyle{false}
     width::T
 end
 SimpleNoRender(x::T) where {T <: Coordinate} = SimpleNoRender{T}(x)

--- a/src/paths/segments/compound.jl
+++ b/src/paths/segments/compound.jl
@@ -1,17 +1,6 @@
 
 """
     struct CompoundSegment{T} <: ContinuousSegment{T}
-        segments::Vector{Segment{T}}
-
-        CompoundSegment(segments) = begin
-            if any(x->isa(x,Corner), segments)
-                error("cannot have corners in a `CompoundSegment`. You may have ",
-                    "tried to simplify a path containing `Corner` objects.")
-            else
-                new(deepcopy(Array(segments)))
-            end
-        end
-    end
 Consider an array of segments as one contiguous segment.
 Useful e.g. for applying styles, uninterrupted over segment changes.
 The array of segments given to the constructor is copied and retained
@@ -32,6 +21,7 @@ struct CompoundSegment{T} <: ContinuousSegment{T}
         end
     end
 end
+
 # Parametric function over the domain [zero(T),pathlength(c)] that represents the
 # compound segments.
 function (s::CompoundSegment{T})(t) where {T}
@@ -68,12 +58,12 @@ function (s::CompoundSegment{T})(t) where {T}
     end
 end
 
-CompoundSegment(nodes::AbstractArray{Node{T},1}) where {T} =
+CompoundSegment(nodes::AbstractVector{Node{T}}) where {T} =
     CompoundSegment{T}(map(segment, nodes))
 
 summary(s::CompoundSegment) = string(length(s.segments), " segments")
-copy(s::CompoundSegment{T}) where {T} = CompoundSegment{T}(s.segments)
-pathlength(s::CompoundSegment{T}) where {T} = sum(pathlength, s.segments)
+copy(s::CompoundSegment) = (typeof(s))(s.segments)
+pathlength(s::CompoundSegment) = sum(pathlength, s.segments)
 
 function setα0p0!(s::CompoundSegment, angle, p::Point)
     setα0p0!(s.segments[1], angle, p)

--- a/src/paths/segments/corner.jl
+++ b/src/paths/segments/corner.jl
@@ -1,17 +1,10 @@
 """
     mutable struct Corner{T} <: DiscreteSegment{T}
-        α::Float64
-        p0::Point{T}
-        α0::Float64
-        extent::T
-        Corner(a) = new(a, Point(zero(T), zero(T)), 0.0, zero(T))
-        Corner(a,b,c,d) = new(a,b,c,d)
-    end
-A corner, or sudden kink in a path. The only parameter is the angle `α` of the
-kink. The kink begins at a point `p0` with initial angle `α0`. It will also
-end at `p0`, since the corner has zero path length. However, during rendering,
-neighboring segments will be tweaked slightly so that the rendered path is
-properly centered about the path function (the rendered corner has a finite width).
+A corner, or sudden kink in a path. The only parameter is the angle `α` of the corner. The
+corner begins at a point `p0` with initial angle `α0`. It will also end at `p0`, since the
+corner has zero path length. However, during rendering, neighboring segments will be tweaked
+slightly so that the rendered path is properly centered about the path function (the
+rendered corner has a finite width).
 """
 mutable struct Corner{T} <: DiscreteSegment{T}
     α::Float64
@@ -24,10 +17,9 @@ end
 
 """
     Corner(α)
-Outer constructor for `Corner{Float64}` segments. If you are using units,
-then you need to specify an appropriate type: `Corner{typeof(1.0nm)}(α)`, for
-example. More likely, you will just use [`corner!`](@ref) rather than
-directly creating a `Corner` object.
+Outer constructor for `Corner{Float64}` segments. If you are using units, then you need to
+specify an appropriate type: `Corner{typeof(1.0nm)}(α)`, for example. More likely, you will
+just use [`corner!`](@ref) rather than directly creating a `Corner` object.
 """
 Corner(α) = Corner{Float64}(α, Point(0.,0.), 0.0, 0.)
 copy(x::Corner{T}) where {T} = Corner{T}(x.α, x.p0, x.α0, x.extent)
@@ -47,16 +39,17 @@ setp0!(s::Corner, p::Point) = s.p0 = p
 setα0!(s::Corner, α0′) = s.α0 = α0′
 summary(s::Corner) = "Corner by $(s.α)"
 
-
 """
-    corner!{T<:Coordinate}(p::Path{T}, α, sty::DiscreteStyle=discretestyle1(p))
+    corner!(p::Path, α, sty::Style=discretestyle1(p))
 Append a sharp turn or "corner" to path `p` with angle `α`.
 
-The style chosen for this corner, if not specified, is the last `DiscreteStyle`
-used in the path.
+The style chosen for this corner, if not specified, is the last `DiscreteStyle` used in the
+path.
 """
-function corner!(p::Path{T}, α, sty::Style=discretestyle1(p)) where {T <: Coordinate}
-    corn = Corner{T}(α)
-    push!(p, Node(corn, convert(DiscreteStyle, sty)))
+function corner!(p::Path, α, sty::Style=discretestyle1(p))
+    T = eltype(p)
+    seg = Corner{T}(α)
+    # convert takes NoRender() → NoRenderDiscrete()
+    push!(p, Node(seg, convert(DiscreteStyle, sty)))
     nothing
 end

--- a/src/paths/segments/straight.jl
+++ b/src/paths/segments/straight.jl
@@ -1,14 +1,7 @@
 """
     mutable struct Straight{T} <: ContinuousSegment{T}
-        l::T
-        p0::Point{T}
-        α0::typeof(0.0°)
-    end
 A straight line segment is parameterized by its length.
 It begins at a point `p0` with initial angle `α0`.
-
-The parametric function describing the line segment is given by
-`t -> p0 + Point(t*cos(α),t*sin(α))` where `t` is a length from 0 to `l`.
 """
 mutable struct Straight{T} <: ContinuousSegment{T}
     l::T
@@ -18,7 +11,7 @@ end
 (s::Straight)(t) = s.p0+Point(t*cos(s.α0), t*sin(s.α0))
 
 """
-    Straight{T<:Coordinate}(l::T; p0::Point=Point(zero(T),zero(T)), α0=0.0°)
+    Straight(l::T; p0::Point=Point(zero(T),zero(T)), α0=0.0°) where {T<:Coordinate}
 Outer constructor for `Straight` segments.
 """
 Straight(l::T; p0::Point=Point(zero(T),zero(T)), α0=0.0°) where {T <: Coordinate} =
@@ -47,18 +40,16 @@ setα0!(s::Straight, α0′) = s.α0 = α0′
 α1(s::Straight) = s.α0
 
 """
-    straight!{T<:Coordinate}(p::Path{T}, l::Coordinate,
-        sty::ContinuousStyle=contstyle1(p))
+    straight!(p::Path, l::Coordinate, sty::Style=contstyle1(p))
 Extend a path `p` straight by length `l` in the current direction. By default,
 we take the last continuous style in the path.
 """
-function straight!(p::Path{T}, l::Coordinate,
-        sty::Style=contstyle1(p)) where {T <: Coordinate}
+function straight!(p::Path, l::Coordinate, sty::Style=contstyle1(p))
+    T = eltype(p)
     dimension(T) != dimension(typeof(l)) && throw(DimensionError(T(1),l))
     @assert l >= zero(l) "tried to go straight by a negative amount."
-    p0 = p1(p)
-    α = α1(p)
-    s = Straight{T}(l, p0, α)
-    push!(p, Node(s, convert(ContinuousStyle, sty)))
+    seg = Straight{T}(l, p1(p), α1(p))
+    # convert takes NoRender() → NoRenderContinuous()
+    push!(p, Node(seg, convert(ContinuousStyle, sty)))
     nothing
 end

--- a/src/render/paths.jl
+++ b/src/render/paths.jl
@@ -1,5 +1,5 @@
 """
-    render!{T}(c::Cell, p::Path{T}, meta::Meta=GDSMeta(); kwargs...)
+    render!(c::Cell, p::Path{T}, meta::Meta=GDSMeta(); kwargs...) where {T}
 Render a path `p` to a cell `c`.
 """
 function render!(c::Cell, p::Path{T}, meta::Meta=GDSMeta(); kwargs...) where {T}
@@ -59,7 +59,7 @@ function handle_generic_tapers!(p)
         tapernode = p[i]
         prevnode = previous(tapernode)
         nextnode = next(tapernode)
-        if prevnode === tapernode || nextnode === tapernode
+        if (prevnode === tapernode) || (nextnode === tapernode)
             error("A generic taper cannot start or finish a path")
         end
         taper_style = get_taper_style(prevnode, nextnode)
@@ -72,6 +72,7 @@ end
 function get_taper_style(prevnode, nextnode)
     prevstyle = style(prevnode)
     nextstyle = style(nextnode)
+    beginof_next = zero(pathlength(segment(nextnode)))
     endof_prev = pathlength(segment(prevnode))
     # handle case of compound style (#39)
     if prevstyle isa Paths.CompoundStyle
@@ -80,15 +81,7 @@ function get_taper_style(prevnode, nextnode)
     if nextstyle isa Paths.CompoundStyle
         nextstyle = first(nextstyle.styles)
     end
-    # handle special case of tapers, set endof_prev to normalized dimensionless parameter
-    if prevstyle isa Paths.TaperTrace || prevstyle isa Paths.TaperCPW
-        endof_prev = endof_prev/endof_prev
-    end
-    beginof_next = zero(pathlength(segment(nextnode)))
-    # handle special case of tapers, set beginof_next to normalized dimensionless parameter
-    if nextstyle isa Paths.TaperTrace || nextstyle isa Paths.TaperCPW
-        beginof_next = beginof_next/pathlength(segment(nextnode))
-    end
+
     if ((prevstyle isa Paths.CPW || prevstyle isa Paths.Trace)
         && nextstyle isa Paths.CPW || nextstyle isa Paths.Trace)
         #special case: both ends are Traces, make a Paths.TaperTrace


### PR DESCRIPTION
It is not possible to write generic code using `extent` unless the second argument is well specified: it should be in `[0,1]` xor `[zero(pathlength(...)), pathlength(...)]`. Previously, it could differ depending on the style; in particular, tapers required some changes.