### PR TITLE
Link to DeviceLayout.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://painterqubits.github.io/Devices.jl/stable)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://painterqubits.github.io/Devices.jl/latest)
 
+> [!TIP]
+> A successor package, [DeviceLayout.jl](https://github.com/aws-cqc/DeviceLayout.jl), has been released. It is derived from Devices.jl and contains many new features and fixes.
+
 # Devices.jl
 
 For simplified generation of device CAD files.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,6 +3,9 @@
 A [Julia](http://julialang.org) package for CAD of electronic devices, in particular
 superconducting devices operating at microwave frequencies.
 
+> [!TIP]
+> A successor package, [DeviceLayout.jl](https://github.com/aws-cqc/DeviceLayout.jl), has been released. It is derived from Devices.jl and contains many new features and fixes.
+
 ## Installation
 
 ### Julia 0.7 and above


### PR DESCRIPTION
[DeviceLayout.jl](https://github.com/aws-cqc/DeviceLayout.jl) is an actively maintained fork of Devices.jl, developed at the AWS Center for Quantum Computing after the primary Devices.jl author joined. In case anyone still uses or comes across Devices.jl, it might be helpful to point them to the new package.